### PR TITLE
Using cat instead of get

### DIFF
--- a/tests/local-extract.js
+++ b/tests/local-extract.js
@@ -12,7 +12,7 @@ async function localExtract (node, name, subtest, fileSet, version) {
   const inserted = await peer.files.add(fileStream)
   const start = process.hrtime()
   const validCID = inserted[0].hash
-  await peer.files.get(validCID)
+  await peer.files.cat(validCID)
   const end = process.hrtime(start)
   return build({
     name: name,


### PR DESCRIPTION
Replaced the IPFS get method with cat for local extract test.