### PR TITLE
fix: added warmup to init node test config

### DIFF
--- a/tests/config/index.js
+++ b/tests/config/index.js
@@ -34,7 +34,7 @@ const tests = { 'unixFsAdd': [{
   'warmup': 'On',
   'fileSet': ['Hundred1KBFile'] } ],
 'initializeNode': [{
-  'warmup': false,
+  'warmup': 'Off',
   'fileSet': ['None'] }]
 }
 


### PR DESCRIPTION
Fix for https://github.com/ipfs/benchmarks/issues/81
```ons-MBP:tests ronlitzenberger$ VERIFYOFF=true node init-node
Swarm listening on /ip4/127.0.0.1/tcp/4022/ws/ipfs/QmSxYJBid9EUdV61T9dUELAsc2FncyQWaSEvm4ztcURiur
Swarm listening on /ip4/127.0.0.1/tcp/4012/ipfs/QmSxYJBid9EUdV61T9dUELAsc2FncyQWaSEvm4ztcURiur
Swarm listening on /ip4/192.168.1.66/tcp/4012/ipfs/QmSxYJBid9EUdV61T9dUELAsc2FncyQWaSEvm4ztcURiur
Swarm listening on /ip4/169.254.184.95/tcp/4012/ipfs/QmSxYJBid9EUdV61T9dUELAsc2FncyQWaSEvm4ztcURiur
Swarm listening on /ip4/127.0.0.1/tcp/3022/ws/ipfs/Qmaa6f8RCQ6UoW28WK7fFFP4Wj22vXTpF3Bg5oKZuqPDuX
Swarm listening on /ip4/127.0.0.1/tcp/7012/ipfs/Qmaa6f8RCQ6UoW28WK7fFFP4Wj22vXTpF3Bg5oKZuqPDuX
Swarm listening on /ip4/192.168.1.66/tcp/7012/ipfs/Qmaa6f8RCQ6UoW28WK7fFFP4Wj22vXTpF3Bg5oKZuqPDuX
Swarm listening on /ip4/169.254.184.95/tcp/7012/ipfs/Qmaa6f8RCQ6UoW28WK7fFFP4Wj22vXTpF3Bg5oKZuqPDuX
Writing output in a multiple files
┌────────────────────┬────────────────────┬──────────────────────────────────────────────────┬────────────────────┬────────────────────┐
│ Test               │ Warmup             │ Description                                      │ File Set           │ Duration           │
├────────────────────┼────────────────────┼──────────────────────────────────────────────────┼────────────────────┼────────────────────┤
│ initializeNode     │ true               │ Initialize node without pre-generated key        │                    │ s:2 ms: 412.474436 │
└────────────────────┴────────────────────┴──────────────────────────────────────────────────┴────────────────────┴────────────────────┘
Removed ./data/ipfs/
rons-MBP:tests ronlitzenberger$
```