### PR TITLE
Prerequisites

### DIFF
--- a/infrastructure/inventory/group_vars/minions.yaml
+++ b/infrastructure/inventory/group_vars/minions.yaml
@@ -7,3 +7,4 @@ remote_user: ubuntu
 # action_user_group: docker
 nodejs_version: "10"
 # docker__users: ["ubuntu", "runner"]
+go_ipfs_version: v0.4.10

--- a/infrastructure/playbooks/benchmarks.yaml
+++ b/infrastructure/playbooks/benchmarks.yaml
@@ -7,7 +7,7 @@
     - name: Update repositories cache and install required packages
       become: yes
       apt:
-        name: [git, build-essential, g++, psmisc]
+        name: [git, build-essential, g++, psmisc, golang-go]
         update_cache: true
         state: present
     - name: Install nvm
@@ -25,6 +25,13 @@
         /bin/bash -c "source ~/.nvm/nvm.sh && npm i clinic autocannon -g"
       args:
         creates: /home/{{ ansible_user_id }}/.nvm/versions/node/v{{ node_version }}/bin/clinic
+    - name: Install clinic and autocannon
+      shell: >
+        wget https://dist.ipfs.io/go-ipfs/{{go_ipfs_version}}/go-ipfs_{{go_ipfs_version}}_linux-386.tar.gz
+        tar xvfz go-ipfs_{{go_ipfs_version}}_linux-386.tar.gz
+        mv go-ipfs/ipfs /usr/local/bin/ipfs
+      args:
+        creates: /usr/local/bin/ipfs
     - file:
         path: ~/ipfs
         state: directory

--- a/infrastructure/playbooks/benchmarks.yaml
+++ b/infrastructure/playbooks/benchmarks.yaml
@@ -7,7 +7,27 @@
     - name: Update repositories cache and install required packages
       become: yes
       apt:
-        name: [git, build-essential, g++, psmisc, golang-go]
+        name:
+          - git
+          - build-essential
+          - g++
+          - psmisc
+          - golang-go
+          - libpangocairo-1.0-0
+          - libx11-xcb1
+          - libxcomposite1
+          - libxcursor1
+          - libxdamage1
+          - libxi6
+          - libxtst6
+          - libnss3
+          - libcups2
+          - libxss1
+          - libxrandr2
+          - libgconf2-4
+          - libasound2
+          - libatk1.0-0
+          - libgtk-3-0
         update_cache: true
         state: present
     - name: Install nvm
@@ -25,13 +45,16 @@
         /bin/bash -c "source ~/.nvm/nvm.sh && npm i clinic autocannon -g"
       args:
         creates: /home/{{ ansible_user_id }}/.nvm/versions/node/v{{ node_version }}/bin/clinic
-    - name: Install clinic and autocannon
+    - name: Install go-ipfs
+      become: yes
       shell: >
-        wget https://dist.ipfs.io/go-ipfs/{{go_ipfs_version}}/go-ipfs_{{go_ipfs_version}}_linux-386.tar.gz
-        tar xvfz go-ipfs_{{go_ipfs_version}}_linux-386.tar.gz
-        mv go-ipfs/ipfs /usr/local/bin/ipfs
+        wget https://dist.ipfs.io/go-ipfs/{{go_ipfs_version}}/go-ipfs_{{go_ipfs_version}}_linux-386.tar.gz && \
+        tar xvfz go-ipfs_{{go_ipfs_version}}_linux-386.tar.gz && \
+        mv go-ipfs/ipfs /usr/local/bin/ipfs_{{go_ipfs_version}} && \
+        rm /usr/local/bin/ipfs && \
+        ln -s /usr/local/bin/ipfs_{{go_ipfs_version}} /usr/local/bin/ipfs
       args:
-        creates: /usr/local/bin/ipfs
+        creates: /usr/local/bin/ipfs_{{go_ipfs_version}}
     - file:
         path: ~/ipfs
         state: directory


### PR DESCRIPTION
Add the pre requisites for go and browser tests
go
```
sudo apt-get update
sudo apt-get install golang-go -y
wget https://dist.ipfs.io/go-ipfs/v0.4.10/go-ipfs_v0.4.10_linux-386.tar.gz
tar xvfz go-ipfs_v0.4.10_linux-386.tar.gz
sudo mv go-ipfs/ipfs /usr/local/bin/ipfs
```
browser
```
sudo apt-get install libpangocairo-1.0-0 libx11-xcb1 libxcomposite1 libxcursor1 libxdamage1 libxi6 libxtst6 libnss3 libcups2 libxss1 libxrandr2 libgconf2-4 libasound2 libatk1.0-0 libgtk-3-0
```