### PR TITLE
Remove js - go tests from runner config

### DIFF
--- a/runner/config.js
+++ b/runner/config.js
@@ -172,22 +172,6 @@ const testAbstracts = [
     file: 'local-add.go.js'
   },
   {
-    name: 'extractJs2Go',
-    file: 'extract-js2.go.js'
-  },
-  {
-    name: 'extractGo2JsWs',
-    file: 'extract-go2.js -t ws'
-  },
-  {
-    name: 'extractJs2GoWs',
-    file: 'extract-js2.go.js -t ws'
-  },
-  {
-    name: 'extractGo2Js',
-    file: 'extract-go2.js'
-  },
-  {
     name: 'peerTransferBrowser',
     file: 'peer-transfer.browser.js'
   },


### PR DESCRIPTION
Need to remove the Js -> go tests due to invalid protocol error.

See Issue  https://github.com/ipfs/benchmarks/issues/214