### PR TITLE
Instruct which benchmarks to run through the API

### DIFF
--- a/runner/API.md
+++ b/runner/API.md
@@ -11,6 +11,7 @@ x-ipfs-benchmarks-api-key
 
 ### Methods
 * GET / - [show tasks](API_SHOW.md)
+* GET /docs - [show test information](API_DOCS.md)
 * POST / - [add task](API_ADD.md)
 * POST /drain - [drain the queue](API_DRAIN.md)
 * POST /restart - [schedule a restart of the runner](API_RESTART.md)

--- a/runner/API_ADD.md
+++ b/runner/API_ADD.md
@@ -13,7 +13,10 @@
 * **Data Params**
 
   * **commit**: Commit SHA from [js-ipfs](https://github.com/ipfs/js-ipfs)
-  * **clinic**: 'on' or 'off' controls whether clinic tools are included in the run.
+  * **clinic**:
+    * **enabled**: 'on' or 'off' controls whether clinic tools are included in the run.
+  * **benchmarks**:
+    * **tests**: Array of benchmark names retrievable from `/docs`
 
 * **Success Response:**
 
@@ -22,7 +25,12 @@
 ```json
         {
           "commit":"b6a7ab63",
-          "clinic":"on",
+          "clinic": {
+            "enabled"; true
+          },
+          "benchmarks": {
+            "tests": ["localTransfer_tcp_mplex", "unixFsAdd"]
+          }
           "remote":true,
           "id":1584093487785384
         }
@@ -41,5 +49,5 @@
 * **Sample Call:**
 
   ```bash
-    curl -XPOST -d '{"commit":"b6a7ab63", "clinic": "on"}' -H "Content-Type: application/json" -H "x-ipfs-benchmarks-api-key: somesecret" -k https://benchmarks.ipfs.team/runner
+    curl -XPOST -d '{"commit":"", "clinic": { "enabled": false },  "benchmarks": { "tests": ["localTransfer_tcp_mplex", "unixFsAdd"]}}' -H "Content-Type: application/json" -H "x-ipfs-benchmarks-api-key: somesecret" -k https://benchmarks.ipfs.team/runner
   ```

--- a/runner/API_DOCS.md
+++ b/runner/API_DOCS.md
@@ -1,0 +1,65 @@
+**Documentation endpoint**
+----
+  Returns a json list of benchmarks and clinic tools.
+
+* **URL**
+
+  /docs
+
+* **Method:**
+
+  `GET`
+
+* **Data Params**
+
+  None
+
+* **Success Response:**
+
+  * **Code:** 200 <br />
+    **Content:**
+```json
+        {
+  "benchmarks": {
+    "tests": [
+      {
+        "name": "localTransfer_tcp_mplex",
+        "file": "local-transfer.js -t tcp -m mplex"
+      },
+      {
+        "name": "localTransfer_ws_mplex",
+        "file": "local-transfer.js -t ws -m mplex"
+      },
+      ...
+      {
+        "name": "pubsubMessage",
+        "file": "pubsub-message.js"
+      }
+    ],
+    "txt": "Benchmarks run with their own set of files mandated by the type of test."
+  },
+  "clinic": {
+    "operations": [
+      "doctor",
+      "flame",
+      "bubbleProf"
+    ],
+    "filesets": [
+      "One4MBFile",
+      "One64MBFile"
+    ],
+    "txt": "For clinic runs you can request to run wit a specific fileset."
+  }
+}
+}
+```
+
+* **Error Response:**
+
+  None
+
+* **Sample Call:**
+
+  ```bash
+    curl -k https://benchmarks.ipfs.team/runner/docs
+  ```

--- a/runner/config.js
+++ b/runner/config.js
@@ -5,29 +5,20 @@ const os = require('os')
 const path = require('path')
 const YAML = require('yaml')
 const Influx = require('influx')
+const util = require('util')
 const Pino = require('pino')
 const PinoPretty = require('pino-pretty')
 const pinoms = require('pino-multi-stream').multistream
 const PinoGetPrettyStream = require('pino/lib/tools').getPrettyStream
-const uuidv1 = require('uuid/v1')
-const util = require('util')
 const mkDir = util.promisify(fs.mkdir)
 
 let pino
 
+const configBenchmarks = require('./lib/configBenchmarks')
 const inventoryPath = process.env.INVENTORY || path.join(__dirname, '../infrastructure/inventory/inventory.yaml')
 const playbookPath = path.join(__dirname, '../infrastructure/playbooks/benchmarks.yaml')
-const remoteTestsPath = process.env.REMOTE_FOLDER || '~/ipfs/tests/'
-const remoteIpfsPath = process.env.REMOTE_FOLDER || '~/ipfs/'
-const tmpOut = '/tmp/out'
-const params = `OUT_FOLDER=${tmpOut} REMOTE=true GUID=${uuidv1()} `
-const remotePreNode = `killall node 2>/dev/null; killall ipfs 2>/dev/null; source ~/.nvm/nvm.sh && `
 const HOME = process.env.HOME || process.env.USERPROFILE
 const keyfile = path.join(HOME, '.ssh', 'id_rsa')
-const tests = []
-const locations = ['local', 'remote']
-const clinicOperations = ['doctor', 'flame', 'bubbleProf']
-const clinicFilesets = ['One4MBFile', 'One64MBFile']
 const memorySuffix = '_memory'
 
 const ipfsAddress = process.env.IPFS_ADDRESS || '/dnsaddr/cluster.ipfs.io'
@@ -75,165 +66,11 @@ const getBenchmarkHostname = () => {
   return getInventory().all.children.minions.hosts
 }
 
-const getCommand = (test, loc) => {
-  return `${loc === 'remote' ? remotePreNode : ''} ${testDefaults.params} node ${testDefaults.path[loc]}/${test.file}`
+let loc = 'remote'
+if (process.env.STAGE === 'local') {
+  loc = 'local'
 }
-
-const getClinicCommands = (test, operation, loc) => {
-  if (locations.includes(loc) && clinicOperations.includes(operation)) {
-    let variations = []
-    for (let fileSet of clinicRuns[operation].fileSets) {
-      let shellCommand = `${loc === 'remote' ? remotePreNode : ''} FILESET="${fileSet}" clinic ${operation} --dest ${tmpOut}/${test.name}/ -- node ${testDefaults.path[loc]}/${test.file}`
-      variations.push({
-        command: shellCommand,
-        fileSet: fileSet,
-        benchmarkName: test.name,
-        operation: operation
-      })
-    }
-    return variations
-  } else {
-    throw Error(`getClinicCommands requires an operation from ${clinicOperations} and a location from ${locations}`)
-  }
-}
-
-const clinicRuns = {
-  doctor: {
-    fileSets: ['One4MBFile', 'One64MBFile']
-  },
-  flame: {
-    fileSets: ['One4MBFile', 'One64MBFile']
-  },
-  bubbleProf: {
-    fileSets: ['One4MBFile']
-  }
-}
-
-const testDefaults = {
-  path: {
-    remote: remoteTestsPath,
-    local: path.join(__dirname, '/../tests')
-  },
-  params: params,
-  remotePreCommand: remotePreNode
-}
-
-const testAbstracts = [
-  {
-    name: 'localTransfer_tcp_mplex',
-    file: 'local-transfer.js -t tcp -m mplex'
-  },
-  {
-    name: 'localTransfer_ws_mplex',
-    file: 'local-transfer.js -t ws -m mplex'
-  },
-  {
-    name: 'localTransfer_ws_mplex',
-    file: 'local-transfer.js -t ws -m mplex'
-  },
-  {
-    name: 'localTransfer_tcp_mplex_secio',
-    file: 'local-transfer.js -t tcp -m mplex -e secio'
-  },
-  {
-    name: 'localTransfer_ws_mplex_secio',
-    file: 'local-transfer.js -t ws -m mplex -e secio'
-  },
-  {
-    name: 'localTransfer_tcp_spdy',
-    file: 'local-transfer.js -t tcp -m spdy'
-  },
-  {
-    name: 'localTransfer_ws_spdy',
-    file: 'local-transfer.js -t ws -m spdy'
-  },
-  {
-    name: 'localTransfer_tcp_spdy_secio',
-    file: 'local-transfer.js -t tcp -m spdy -e secio'
-  },
-  {
-    name: 'localTransfer_ws_spdy_secio',
-    file: 'local-transfer.js -t ws -m spdy -e secio'
-  },
-  {
-    name: 'unixFsAdd',
-    file: 'local-add.js'
-  },
-  {
-    name: 'unixFsAddTrickle',
-    file: 'local-add.js trickle'
-  },
-  {
-    name: 'localExtract',
-    file: 'local-extract.js'
-  },
-  {
-    name: 'multiPeerTransfer',
-    file: 'multi-peer-transfer.js'
-  },
-  {
-    name: 'addMultiKb',
-    file: 'add-multi-kb.js'
-  },
-  {
-    name: 'addMultiKbTrickle',
-    file: 'add-multi-kb.js trickle'
-  },
-  {
-    name: 'initializeNodeBrowser',
-    file: 'init-node.browser.js'
-  },
-  {
-    name: 'unixFsAddBrowser',
-    file: 'local-add.browser.js'
-  },
-  {
-    name: 'addMultiKbBrowser',
-    file: 'add-multi-kb.browser.js'
-  },
-  {
-    name: 'unixFsAddGo',
-    file: 'local-add.go.js'
-  },
-  {
-    name: 'extractJs2Go',
-    file: 'extract-js2.go.js'
-  },
-  {
-    name: 'extractGo2JsWs',
-    file: 'extract-go2.js -t ws'
-  },
-  {
-    name: 'extractJs2GoWs',
-    file: 'extract-js2.go.js -t ws'
-  },
-  {
-    name: 'extractGo2Js',
-    file: 'extract-go2.js'
-  },
-  {
-    name: 'peerTransferBrowser',
-    file: 'peer-transfer.browser.js'
-  },
-  {
-    name: 'pubsubMessage',
-    file: 'pubsub-message.js'
-  }
-]
-
-for (let test of testAbstracts) {
-  let loc = 'remote'
-  if (process.env.STAGE === 'local') {
-    loc = 'local'
-  }
-  tests.push({
-    name: test.name,
-    benchmark: getCommand(test, loc),
-    doctor: getClinicCommands(test, 'doctor', loc),
-    flame: getClinicCommands(test, 'flame', loc),
-    bubbleProf: getClinicCommands(test, 'bubbleProf', loc)
-  })
-}
+const tests = configBenchmarks.constructTests(loc)
 
 const runClinic = (process.env.CLINIC && (process.env.CLINIC === 'ON' || process.env.CLINIC === true)) || false
 
@@ -243,7 +80,7 @@ const config = {
   },
   log: pino,
   stage: process.env.STAGE || 'local',
-  outFolder: process.env.OUT_FOLDER || tmpOut,
+  outFolder: process.env.OUT_FOLDER || configBenchmarks.tmpOut,
   dataDir: process.env.DATADIR || './data/',
   logFile: logFile, // where we store all the stuff that is to be sent to IPFS
   now: now,
@@ -253,11 +90,11 @@ const config = {
     apikey: process.env.API_KEY || 'supersecret',
     api: {
       clinic: {
-        operations: clinicOperations,
-        filesets: clinicFilesets
+        operations: configBenchmarks.clinicOperations,
+        filesets: configBenchmarks.clinicFilesets
       },
       benchmarks: {
-        tests: testAbstracts
+        tests: configBenchmarks.testAbstracts
       }
     }
   },
@@ -311,15 +148,15 @@ const config = {
     user: process.env.BENCHMARK_USER || 'elexy',
     key: process.env.BENCHMARK_KEY || keyfile,
     path: path.join(__dirname, '../tests'),
-    remotePath: remoteTestsPath,
+    remotePath: configBenchmarks.remoteTestsPath,
     tests: tests,
-    cleanup: `rm -Rf ${tmpOut}/*`,
+    cleanup: `rm -Rf ${configBenchmarks.tmpOut}/*`,
     measurements: {
       memory: memorySuffix
     }
   },
   ipfs: {
-    path: remoteIpfsPath,
+    path: configBenchmarks.remoteIpfsPath,
     network: {
       address: ipfsAddress,
       user: ipfsUser,

--- a/runner/config.js
+++ b/runner/config.js
@@ -27,6 +27,7 @@ const keyfile = path.join(HOME, '.ssh', 'id_rsa')
 const tests = []
 const locations = ['local', 'remote']
 const clinicOperations = ['doctor', 'flame', 'bubbleProf']
+const clinicFilesets = ['One4MBFile', 'One64MBFile']
 const memorySuffix = '_memory'
 
 const ipfsAddress = process.env.IPFS_ADDRESS || '/dnsaddr/cluster.ipfs.io'
@@ -249,7 +250,16 @@ const config = {
   db: 'ipfs-db',
   server: {
     port: 9000,
-    apikey: process.env.API_KEY || 'supersecret'
+    apikey: process.env.API_KEY || 'supersecret',
+    api: {
+      clinic: {
+        operations: clinicOperations,
+        filesets: clinicFilesets
+      },
+      benchmarks: {
+        tests: testAbstracts
+      }
+    }
   },
   influxdb: {
     host: process.env.INFLUX_HOST || 'localhost',

--- a/runner/index.js
+++ b/runner/index.js
@@ -52,6 +52,7 @@ fastify.route({
     let task = queue.add({
       commit: request.body.commit,
       clinic: request.body.clinic,
+      benchmarks: request.body.benchmarks,
       remote: true,
       nightly: true
     })

--- a/runner/index.js
+++ b/runner/index.js
@@ -8,6 +8,12 @@ const schema = require('./schema')
 const config = require('./config')
 const runner = require('./runner')
 const Queue = require('./queue')
+const docs = {
+  benchmarks: config.server.api.benchmarks,
+  clinic: config.server.api.clinic
+}
+docs.benchmarks.txt = `Benchmarks run with their own set of files mandated by the type of test.`
+docs.clinic.txt = `For clinic runs you can request to run wit a specific fileset.`
 
 // This function exits the main process, relying on process manager to restart
 // so that a new version of the runner can be applied on next startup
@@ -61,6 +67,16 @@ fastify.route({
     let status = queue.getStatus()
     fastify.log.info('getting queue status', status)
     return status
+  }
+})
+
+// list
+fastify.route({
+  method: 'GET',
+  url: '/docs',
+  handler: async (request, reply) => {
+    fastify.log.info('getting API docs')
+    return docs
   }
 })
 

--- a/runner/lib/configBenchmarks.js
+++ b/runner/lib/configBenchmarks.js
@@ -1,0 +1,194 @@
+'use strict'
+
+const path = require('path')
+const _ = require('lodash')
+const remoteTestsPath = process.env.REMOTE_FOLDER || '~/ipfs/tests/'
+const remoteIpfsPath = process.env.REMOTE_FOLDER || '~/ipfs/'
+const uuidv1 = require('uuid/v1')
+const locations = ['local', 'remote']
+const clinicOperations = ['doctor', 'flame', 'bubbleProf']
+const clinicFilesets = ['One4MBFile', 'One64MBFile']
+const tmpOut = '/tmp/out'
+const params = `OUT_FOLDER=${tmpOut} REMOTE=true GUID=${uuidv1()} `
+const remotePreNode = `killall node 2>/dev/null; killall ipfs 2>/dev/null; source ~/.nvm/nvm.sh && `
+
+const testAbstracts = [
+  {
+    name: 'localTransfer_tcp_mplex',
+    file: 'local-transfer.js -t tcp -m mplex'
+  },
+  {
+    name: 'localTransfer_ws_mplex',
+    file: 'local-transfer.js -t ws -m mplex'
+  },
+  {
+    name: 'localTransfer_ws_mplex',
+    file: 'local-transfer.js -t ws -m mplex'
+  },
+  {
+    name: 'localTransfer_tcp_mplex_secio',
+    file: 'local-transfer.js -t tcp -m mplex -e secio'
+  },
+  {
+    name: 'localTransfer_ws_mplex_secio',
+    file: 'local-transfer.js -t ws -m mplex -e secio'
+  },
+  {
+    name: 'localTransfer_tcp_spdy',
+    file: 'local-transfer.js -t tcp -m spdy'
+  },
+  {
+    name: 'localTransfer_ws_spdy',
+    file: 'local-transfer.js -t ws -m spdy'
+  },
+  {
+    name: 'localTransfer_tcp_spdy_secio',
+    file: 'local-transfer.js -t tcp -m spdy -e secio'
+  },
+  {
+    name: 'localTransfer_ws_spdy_secio',
+    file: 'local-transfer.js -t ws -m spdy -e secio'
+  },
+  {
+    name: 'unixFsAdd',
+    file: 'local-add.js'
+  },
+  {
+    name: 'unixFsAddTrickle',
+    file: 'local-add.js trickle'
+  },
+  {
+    name: 'localExtract',
+    file: 'local-extract.js'
+  },
+  {
+    name: 'multiPeerTransfer',
+    file: 'multi-peer-transfer.js'
+  },
+  {
+    name: 'addMultiKb',
+    file: 'add-multi-kb.js'
+  },
+  {
+    name: 'addMultiKbTrickle',
+    file: 'add-multi-kb.js trickle'
+  },
+  {
+    name: 'initializeNodeBrowser',
+    file: 'init-node.browser.js'
+  },
+  {
+    name: 'unixFsAddBrowser',
+    file: 'local-add.browser.js'
+  },
+  {
+    name: 'addMultiKbBrowser',
+    file: 'add-multi-kb.browser.js'
+  },
+  {
+    name: 'unixFsAddGo',
+    file: 'local-add.go.js'
+  },
+  {
+    name: 'extractJs2Go',
+    file: 'extract-js2.go.js'
+  },
+  {
+    name: 'extractGo2JsWs',
+    file: 'extract-go2.js -t ws'
+  },
+  {
+    name: 'extractJs2GoWs',
+    file: 'extract-js2.go.js -t ws'
+  },
+  {
+    name: 'extractGo2Js',
+    file: 'extract-go2.js'
+  },
+  {
+    name: 'peerTransferBrowser',
+    file: 'peer-transfer.browser.js'
+  },
+  {
+    name: 'pubsubMessage',
+    file: 'pubsub-message.js'
+  }
+]
+
+const clinicRuns = {
+  doctor: {
+    fileSets: ['One4MBFile', 'One64MBFile']
+  },
+  flame: {
+    fileSets: ['One4MBFile', 'One64MBFile']
+  },
+  bubbleProf: {
+    fileSets: ['One4MBFile']
+  }
+}
+
+const testDefaults = {
+  path: {
+    remote: remoteTestsPath,
+    local: path.join(__dirname, '/../tests')
+  },
+  params: params,
+  remotePreCommand: remotePreNode
+}
+
+const getCommand = (test, loc) => {
+  return `${loc === 'remote' ? remotePreNode : ''} ${testDefaults.params} node ${testDefaults.path[loc]}/${test.file}`
+}
+
+const getClinicCommands = (test, operation, loc) => {
+  if (locations.includes(loc) && clinicOperations.includes(operation)) {
+    let variations = []
+    for (let fileSet of clinicRuns[operation].fileSets) {
+      let shellCommand = `${loc === 'remote' ? remotePreNode : ''} FILESET="${fileSet}" clinic ${operation} --dest ${tmpOut}/${test.name}/ -- node ${testDefaults.path[loc]}/${test.file}`
+      variations.push({
+        command: shellCommand,
+        fileSet: fileSet,
+        benchmarkName: test.name,
+        operation: operation
+      })
+    }
+    return variations
+  } else {
+    throw Error(`getClinicCommands requires an operation from ${clinicOperations} and a location from ${locations}`)
+  }
+}
+
+const constructTests = (loc, doClinic, testNames) => {
+  let tests = []
+  let testItems = []
+  if (testNames && testNames.length > 0) {
+    testItems = testNames
+  } else {
+    testItems = testAbstracts
+  }
+  for (let testAbstract of testItems) {
+    if (typeof testAbstract === 'string') {
+      testAbstract = _.find(testAbstracts, { name: testAbstract })
+    }
+    let test = {
+      name: testAbstract.name,
+      benchmark: getCommand(testAbstract, loc)
+    }
+    if (doClinic) {
+      test.doctor = getClinicCommands(testAbstract, 'doctor', loc)
+      test.flame = getClinicCommands(testAbstract, 'flame', loc)
+      test.bubbleProf = getClinicCommands(testAbstract, 'bubbleProf', loc)
+    }
+    tests.push(test)
+  }
+  return tests
+}
+
+module.exports = {
+  testAbstracts,
+  constructTests,
+  tmpOut,
+  remoteIpfsPath,
+  clinicOperations,
+  clinicFilesets
+}

--- a/runner/lib/configBenchmarks.js
+++ b/runner/lib/configBenchmarks.js
@@ -189,6 +189,7 @@ module.exports = {
   constructTests,
   tmpOut,
   remoteIpfsPath,
+  remoteTestsPath,
   clinicOperations,
   clinicFilesets
 }

--- a/runner/runner.js
+++ b/runner/runner.js
@@ -42,10 +42,6 @@ const clearFile = async (path) => {
   fs.closeSync(fd)
 }
 
-const matchBenchmark = (benchmarkNames, loc) => {
-  return configBenchmarks.constructTest(benchmarkNames, loc)
-}
-
 const run = async (params) => {
   config.log.debug(params)
   // start with a clean logfile
@@ -72,10 +68,10 @@ const run = async (params) => {
   let benchmarks
   if (params.benchmarks && params.benchmarks.tests && params.benchmarks.tests.length) {
     config.log.info(`Running benchmarks from parameters: ${JSON.stringify(params.benchmarks.tests)}`)
-    benchmarks = configBenchmarks.constructTests(params.benchmarks.tests, config.stage, params.clinic)
+    benchmarks = configBenchmarks.constructTests(config.stage, params.clinic.enabled, params.benchmarks.tests)
     console.log(benchmarks)
   } else {
-    config.log.info('Running default benchmarks')
+    config.log.info('Running ALL default benchmarks')
     benchmarks = config.benchmarks.tests
   }
   for (let test of benchmarks) {
@@ -97,8 +93,8 @@ const run = async (params) => {
       config.log.error(e)
       // TODO:  maybe trigger an alert here ??
     }
-    if (config.benchmarks.clinic || params.clinic) { // then run it with each of the clinic tools
-      config.log.info(`Running clinic: default [${config.benchmarks.clinic}] param [${params.clinic}]`)
+    if (config.benchmarks.clinic || params.clinic.enabled) { // then run it with each of the clinic tools
+      config.log.info(`Running clinic: default [${config.benchmarks.clinic}] param [${params.clinic.enabled}]`)
       try {
         for (let op of ['doctor', 'flame', 'bubbleProf']) {
           for (let run of test[op]) {
@@ -116,7 +112,7 @@ const run = async (params) => {
         config.log.error(e)
       }
     } else {
-      config.log.info(`not running clinic: default [${config.benchmarks.clinic}] param [${params.clinic}]`)
+      config.log.info(`not running clinic: default [${config.benchmarks.clinic}] param [${params.clinic.enabled}]`)
     }
   }
   try {

--- a/runner/schema.js
+++ b/runner/schema.js
@@ -16,7 +16,19 @@ const addBody = {
   type: 'object',
   properties: {
     commit: { type: 'string' },
-    clinic: { type: 'boolean', default: true }
+    benchmarks: {
+      type: 'object',
+      properties: {
+        tests: { type: 'array' }
+      }
+    },
+    clinic: {
+      type: 'object',
+      properties: {
+        enabled: { type: 'boolean', default: false },
+        tests: { type: 'array' }
+      }
+    }
   },
   required: ['commit']
 }


### PR DESCRIPTION
This pulls out more of the configuration to the API.
You can specify which benchmarks to run and if ALL the clinic tools should be run on each of them.
```shell
curl -XPOST -d '{"commit":"", "clinic": { "enabled": false },  "benchmarks": { "tests": ["localTransfer_tcp_mplex", "unixFsAdd"]}}' -H "Content-Type: application/json" -H "x-ipfs-benchmarks-api-key: supersecret" -k http://localhost:9000
```