### PR TITLE
skip non existent tests

### DIFF
--- a/runner/lib/configBenchmarks.js
+++ b/runner/lib/configBenchmarks.js
@@ -182,16 +182,18 @@ const constructTests = (loc, doClinic, testNames) => {
     if (typeof testAbstract === 'string') {
       testAbstract = _.find(testAbstracts, { name: testAbstract })
     }
-    let test = {
-      name: testAbstract.name,
-      benchmark: getCommand(testAbstract, loc)
+    if (testAbstract) {
+      let test = {
+        name: testAbstract.name,
+        benchmark: getCommand(testAbstract, loc)
+      }
+      if (doClinic) {
+        test.doctor = getClinicCommands(testAbstract, 'doctor', loc)
+        test.flame = getClinicCommands(testAbstract, 'flame', loc)
+        test.bubbleProf = getClinicCommands(testAbstract, 'bubbleProf', loc)
+      }
+      tests.push(test)
     }
-    if (doClinic) {
-      test.doctor = getClinicCommands(testAbstract, 'doctor', loc)
-      test.flame = getClinicCommands(testAbstract, 'flame', loc)
-      test.bubbleProf = getClinicCommands(testAbstract, 'bubbleProf', loc)
-    }
-    tests.push(test)
   }
   return tests
 }

--- a/runner/runner.js
+++ b/runner/runner.js
@@ -67,9 +67,13 @@ const run = async (params) => {
   }
   let benchmarks
   if (params.benchmarks && params.benchmarks.tests && params.benchmarks.tests.length) {
-    config.log.info(`Running benchmarks from parameters: ${JSON.stringify(params.benchmarks.tests)}`)
+    const testsJson = JSON.stringify(params.benchmarks.tests)
+    config.log.info(`Running benchmarks from parameters: ${testsJson}`)
     benchmarks = configBenchmarks.constructTests(config.stage, params.clinic.enabled, params.benchmarks.tests)
-    console.log(benchmarks)
+    config.log.error(`The following benchmarks were constructed ${JSON.stringify(benchmarks)}`)
+    if (!benchmarks) {
+      config.log.error(`no valid benchmarks found in ${testsJson}`)
+    }
   } else {
     config.log.info('Running ALL default benchmarks')
     benchmarks = config.benchmarks.tests

--- a/runner/test/configBenchmarks.js
+++ b/runner/test/configBenchmarks.js
@@ -1,0 +1,73 @@
+'use srict'
+
+const tap = require('tap')
+const configBenchmarks = require('../lib/configBenchmarks')
+
+tap.test('construct a single test', async (t) => {
+  let benchmarks = configBenchmarks.constructTests(
+    'remote',
+    false,
+    ['unixFsAddBrowser_balanced']
+  )
+  tap.equal(benchmarks[0].name, 'unixFsAddBrowser_balanced', 'check test name')
+  tap.equal(benchmarks.length, 1, 'should be 1 test')
+  tap.contains(benchmarks[0].benchmark, 'local-add.browser.js', 'check test file')
+  t.end()
+})
+
+tap.test('construct a 2 tests', async (t) => {
+  let benchmarks = configBenchmarks.constructTests(
+    'remote',
+    false,
+    ['unixFsAddBrowser_balanced', 'addMultiKbBrowser_balanced']
+  )
+  tap.equal(benchmarks[0].name, 'unixFsAddBrowser_balanced', 'check first test name')
+  tap.equal(benchmarks[1].name, 'addMultiKbBrowser_balanced', 'check second test name')
+  tap.equal(benchmarks.length, 2, 'should be 2 tests')
+  t.end()
+})
+
+tap.test('construct a 1 non-existing and 1 existing test', async (t) => {
+  let benchmarks = configBenchmarks.constructTests(
+    'remote',
+    false,
+    ['blahblah', 'addMultiKbBrowser_balanced']
+  )
+  tap.equal(benchmarks[0].name, 'addMultiKbBrowser_balanced', 'check first and only test name')
+  tap.equal(benchmarks.length, 1, 'should be 1 tests')
+  t.end()
+})
+
+tap.test('non existent testname', async (t) => {
+  let benchmarks = configBenchmarks.constructTests(
+    'remote',
+    false,
+    ['blablah']
+  )
+  tap.equal(benchmarks.length, 0, 'there should be no test')
+  t.end()
+})
+
+tap.test('default tests', async (t) => {
+  let benchmarks = configBenchmarks.constructTests(
+    'remote',
+    false
+  )
+  tap.equal(benchmarks.length, configBenchmarks.testAbstracts.length, 'compare # constructed to # abstracts')
+  t.end()
+})
+
+tap.test('construct a single test with clinic', async (t) => {
+  let benchmarks = configBenchmarks.constructTests(
+    'remote',
+    true,
+    ['unixFsAddBrowser_balanced']
+  )
+  tap.equal(benchmarks[0].name, 'unixFsAddBrowser_balanced', 'check test name')
+  tap.equal(benchmarks.length, 1, 'should be 1 test')
+  tap.equal(typeof benchmarks[0]['doctor'] === 'undefined', false, 'contains doctor property')
+  tap.equal(typeof benchmarks[0]['flame'] === 'undefined', false, 'contains flame property')
+  tap.equal(typeof benchmarks[0]['bubbleProf'] === 'undefined', false, 'contains bubbleProf property')
+  tap.equal(typeof benchmarks[0]['blahblah'] === 'undefined', true, 'does not contain blahblah property')
+  t.end()
+})


### PR DESCRIPTION
If a test is requested that is not known by the runner, it just skips it now.
The logs will show a difference:
```
[2019-02-14 19:18:44.441 +0000] INFO (runner/49365 on mbpro-3055.local): Running benchmarks from parameters: ["unixFsAdd_balanced_memory","localTransfer_tcp_mplex_secio"]
[2019-02-14 19:18:44.442 +0000] ERROR (runner/49365 on mbpro-3055.local): The following benchmarks were constructed [{"name":"localTransfer_tcp_mplex_secio","benchmark":"killall node 2>/dev/null; killall ipfs 2>/dev/null; source ~/.nvm/nvm.sh &&  OUT_FOLDER=/tmp/out REMOTE=true GUID=3e7ca970-308d-11e9-a874-ed2dd61d2f73  node ~/ipfs/tests//local-transfer.js -t tcp -m mplex -e secio","doctor":[{"command":"killall node 2>/dev/null; killall ipfs 2>/dev/null; source ~/.nvm/nvm.sh &&  FILESET=\"One4MBFile\" clinic doctor --dest /tmp/out/localTransfer_tcp_mplex_secio/ -- node ~/ipfs/tests//local-transfer.js -t tcp -m mplex -e secio","fileSet":"One4MBFile","benchmarkName":"localTransfer_tcp_mplex_secio","operation":"doctor"},{"command":"killall node 2>/dev/null; killall ipfs 2>/dev/null; source ~/.nvm/nvm.sh &&  FILESET=\"One64MBFile\" clinic doctor --dest /tmp/out/localTransfer_tcp_mplex_secio/ -- node ~/ipfs/tests//local-transfer.js -t tcp -m mplex -e secio","fileSet":"One64MBFile","benchmarkName":"localTransfer_tcp_mplex_secio","operation":"doctor"}],"flame":[{"command":"killall node 2>/dev/null; killall ipfs 2>/dev/null; source ~/.nvm/nvm.sh &&  FILESET=\"One4MBFile\" clinic flame --dest /tmp/out/localTransfer_tcp_mplex_secio/ -- node ~/ipfs/tests//local-transfer.js -t tcp -m mplex -e secio","fileSet":"One4MBFile","benchmarkName":"localTransfer_tcp_mplex_secio","operation":"flame"},{"command":"killall node 2>/dev/null; killall ipfs 2>/dev/null; source ~/.nvm/nvm.sh &&  FILESET=\"One64MBFile\" clinic flame --dest /tmp/out/localTransfer_tcp_mplex_secio/ -- node ~/ipfs/tests//local-transfer.js -t tcp -m mplex -e secio","fileSet":"One64MBFile","benchmarkName":"localTransfer_tcp_mplex_secio","operation":"flame"}],"bubbleProf":[{"command":"killall node 2>/dev/null; killall ipfs 2>/dev/null; source ~/.nvm/nvm.sh &&  FILESET=\"One4MBFile\" clinic bubbleProf --dest /tmp/out/localTransfer_tcp_mplex_secio/ -- node ~/ipfs/tests//local-transfer.js -t tcp -m mplex -e secio","fileSet":"One4MBFile","benchmarkName":"localTransfer_tcp_mplex_secio","operation":"bubbleProf"}]}]
```