### PR TITLE
Fix link to video

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ submitting code to the community.
 * Using the [Runner](runner/README.md) to manage benchmark runs remotely, which includes an [API](https://benchmarks.ipfs.team/runner/docs/index.html) available [here](https://benchmarks.ipfs.team/runner)
 * Description of [tests](tests/README.md)
 * Convenience [scripts](scripts/README.md) for the docker-compose [deployment](infrastructure/deploy/README.md)
-* Overview [video](https://cloudflare-ipfs.com/ipfs/QmSZgcL7dyjcifZ5uJYmBDCCACfzQD5Ve2RFSoB4RdYATp) hosted on the IPFS network.
+* Overview [video](https://ipfs.io/ipfs/QmSZgcL7dyjcifZ5uJYmBDCCACfzQD5Ve2RFSoB4RdYATp) hosted on the IPFS network.
 * [Introduction to Clinic.js in the context of IPFS](https://github.com/ipfs/team-mgmt/issues/796) [Recording](https://nearform.zoom.us/recording/play/A-4Vn3jA5aeK9BCPwKCA44IfwpLZePIBlzvD1bUYF7JqTXnG2JptVaLEVcRUmQ1i)
 
 ## Benchmarks on the web


### PR DESCRIPTION
Cloudflare doesn't allow streaming video on their gateway anymore.