### PR TITLE
Initial changes to support go-ipfs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,8 @@ tests/browser/.env.production.local
 tests/browser/npm-debug.log*
 tests/browser/yarn-debug.log*
 tests/browser/yarn-error.log*
+
+# Environment settings
+.env*
+
+

--- a/infrastructure/grafana/dashboard-go-ipfs.json
+++ b/infrastructure/grafana/dashboard-go-ipfs.json
@@ -16,8 +16,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 8,
-  "iteration": 1549558529330,
+  "id": 2,
+  "iteration": 1564548299977,
   "links": [],
   "panels": [
     {
@@ -33,7 +33,7 @@
         "x": 0,
         "y": 0
       },
-      "id": 4,
+      "id": 6,
       "legend": {
         "alignAsTable": true,
         "avg": true,
@@ -51,11 +51,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "connected",
+      "options": {},
       "percentage": false,
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
-      "repeat": null,
       "repeatDirection": "h",
       "seriesOverrides": [
         {}
@@ -131,14 +131,21 @@
               "key": "tag",
               "operator": "=~",
               "value": "/^$tag$/"
+            },
+            {
+              "condition": "AND",
+              "key": "project",
+              "operator": "=",
+              "value": "go-ipfs"
             }
           ]
         }
       ],
       "thresholds": [],
       "timeFrom": null,
+      "timeRegions": [],
       "timeShift": null,
-      "title": "Benchmarks",
+      "title": "Benchmarks - go-ipfs",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -177,7 +184,6 @@
     },
     {
       "columns": [],
-      "datasource": null,
       "fontSize": "100%",
       "gridPos": {
         "h": 6,
@@ -187,6 +193,7 @@
       },
       "id": 2,
       "links": [],
+      "options": {},
       "pageSize": null,
       "scroll": true,
       "showHeader": true,
@@ -293,7 +300,7 @@
       "type": "table"
     }
   ],
-  "schemaVersion": 16,
+  "schemaVersion": 18,
   "style": "dark",
   "tags": [],
   "templating": {
@@ -367,13 +374,13 @@
       {
         "allValue": null,
         "current": {
-          "tags": [],
           "text": "All",
           "value": [
             "$__all"
           ]
         },
         "datasource": "influxdb",
+        "definition": "",
         "hide": 0,
         "includeAll": true,
         "label": null,
@@ -398,6 +405,7 @@
           "value": "off"
         },
         "datasource": "influxdb",
+        "definition": "",
         "hide": 0,
         "includeAll": false,
         "label": null,
@@ -422,6 +430,7 @@
           "value": "OneMBFile"
         },
         "datasource": "influxdb",
+        "definition": "",
         "hide": 0,
         "includeAll": false,
         "label": null,
@@ -445,11 +454,10 @@
           "value": ""
         },
         "hide": 0,
-        "label": "js-ipfs commit SHA",
+        "label": "go-ipfs commit SHA",
         "name": "commit",
         "options": [
           {
-            "selected": true,
             "text": "",
             "value": ""
           }
@@ -467,6 +475,7 @@
           ]
         },
         "datasource": "influxdb",
+        "definition": "",
         "hide": 0,
         "includeAll": true,
         "label": null,
@@ -516,7 +525,7 @@
     ]
   },
   "timezone": "utc",
-  "title": "IPFS benchmarks",
-  "uid": "HCaaM78mk",
-  "version": 2
+  "title": "IPFS benchmarks - go-ipfs",
+  "uid": "GtGqynvZz",
+  "version": 3
 }

--- a/infrastructure/grafana/dashboard-js-ipfs.json
+++ b/infrastructure/grafana/dashboard-js-ipfs.json
@@ -1,0 +1,532 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Show duration, memory use or cpu use for all benchmarks",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 1,
+  "iteration": 1564548025981,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "influxdb",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 5,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "hideEmpty": true,
+        "hideZero": true,
+        "max": true,
+        "min": true,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {},
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeatDirection": "h",
+      "seriesOverrides": [
+        {}
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "$m",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            },
+            {
+              "params": [
+                "none"
+              ],
+              "type": "fill"
+            }
+          ],
+          "hide": false,
+          "measurement": "/^$Measurement$/",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT distinct(\"duration\") FROM /^$Measurement$/ WHERE (\"file_set\" =~ /^$FileSet$/ AND \"warmup\" =~ /^$Warmup$/ AND \"commit\" =~ /$commit/ AND \"nightly\" =~ /^$nightly$/) AND $timeFilter GROUP BY time($__interval) fill(none)",
+          "rawQuery": false,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "$Metric"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": [
+            {
+              "key": "file_set",
+              "operator": "=~",
+              "value": "/^$FileSet$/"
+            },
+            {
+              "condition": "AND",
+              "key": "warmup",
+              "operator": "=~",
+              "value": "/^$Warmup$/"
+            },
+            {
+              "condition": "AND",
+              "key": "commit",
+              "operator": "=~",
+              "value": "/$commit/"
+            },
+            {
+              "condition": "AND",
+              "key": "nightly",
+              "operator": "=~",
+              "value": "/^$nightly$/"
+            },
+            {
+              "condition": "AND",
+              "key": "tag",
+              "operator": "=~",
+              "value": "/^$tag$/"
+            },
+            {
+              "condition": "AND",
+              "key": "project",
+              "operator": "=",
+              "value": "js-ipfs"
+            }
+          ]
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Benchmarks - js-ipfs",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 10,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "columns": [],
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 2,
+      "links": [],
+      "options": {},
+      "pageSize": null,
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 0,
+        "desc": true
+      },
+      "styles": [
+        {
+          "alias": "Time",
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "pattern": "Time",
+          "type": "date"
+        },
+        {
+          "alias": "IPFS url",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "link": true,
+          "linkTargetBlank": true,
+          "linkTooltip": "",
+          "linkUrl": "https://cloudflare-ipfs.com/ipfs/${__cell}",
+          "mappingType": 1,
+          "pattern": "ipfs_sha",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short",
+          "valueMaps": []
+        },
+        {
+          "alias": "",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "link": true,
+          "mappingType": 1,
+          "pattern": "sha",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "groupBy": [
+            {
+              "params": [
+                "sha"
+              ],
+              "type": "tag"
+            }
+          ],
+          "limit": "",
+          "measurement": "/^$Measurement$/",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "refId": "A",
+          "resultFormat": "table",
+          "select": [
+            [
+              {
+                "params": [
+                  "ipfs_sha"
+                ],
+                "type": "field"
+              }
+            ]
+          ],
+          "slimit": "",
+          "tags": [
+            {
+              "key": "file_set",
+              "operator": "=~",
+              "value": "/^$FileSet$/"
+            },
+            {
+              "condition": "AND",
+              "key": "warmup",
+              "operator": "=~",
+              "value": "/^$Warmup$/"
+            },
+            {
+              "condition": "AND",
+              "key": "commit",
+              "operator": "=~",
+              "value": "/$commit/"
+            }
+          ]
+        }
+      ],
+      "title": "Links",
+      "transform": "table",
+      "type": "table"
+    }
+  ],
+  "schemaVersion": 18,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "duration",
+          "value": "duration"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "Metric",
+        "options": [
+          {
+            "selected": true,
+            "text": "duration",
+            "value": "duration"
+          },
+          {
+            "selected": false,
+            "text": "cpu",
+            "value": "cpu"
+          },
+          {
+            "selected": false,
+            "text": "memory",
+            "value": "memory"
+          }
+        ],
+        "query": "duration,cpu,memory",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "allValue": "",
+        "current": {
+          "tags": [],
+          "text": "All",
+          "value": "$__all"
+        },
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": false,
+        "name": "nightly",
+        "options": [
+          {
+            "selected": true,
+            "text": "All",
+            "value": "$__all"
+          },
+          {
+            "selected": false,
+            "text": "true",
+            "value": "true"
+          },
+          {
+            "selected": false,
+            "text": "false",
+            "value": "false"
+          }
+        ],
+        "query": "true,false",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "influxdb",
+        "definition": "",
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "Measurement",
+        "options": [],
+        "query": "show measurements",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "text": "off",
+          "value": "off"
+        },
+        "datasource": "influxdb",
+        "definition": "",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "Warmup",
+        "options": [],
+        "query": "SHOW TAG VALUES WITH KEY = \"warmup\"  ",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "text": "OneMBFile",
+          "value": "OneMBFile"
+        },
+        "datasource": "influxdb",
+        "definition": "",
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "FileSet",
+        "options": [],
+        "query": "SHOW TAG VALUES WITH KEY = \"file_set\"  ",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "hide": 0,
+        "label": "js-ipfs commit SHA",
+        "name": "commit",
+        "options": [
+          {
+            "selected": true,
+            "text": "",
+            "value": ""
+          }
+        ],
+        "query": "",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "allValue": "*",
+        "current": {
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "influxdb",
+        "definition": "",
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "tag",
+        "options": [],
+        "query": "show TAG values WITH KEY = \"tag\"",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now/d",
+    "to": "now/d"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "utc",
+  "title": "IPFS benchmarks - js-ipfs",
+  "uid": "HCaaM78mk",
+  "version": 3
+}

--- a/runner/cli.js
+++ b/runner/cli.js
@@ -8,7 +8,8 @@ const opts = {
   url: `http://localhost:${config.server.port}/`,
   body: {
     commit: argv.commit || '',
-    clinic: argv.clinic || 'true'
+    project: argv.project || '',
+    clinic: argv.clinic || { enabled: false }
   },
   json: true,
   headers: {

--- a/runner/lib/configBenchmarks.js
+++ b/runner/lib/configBenchmarks.js
@@ -176,7 +176,8 @@ const constructTests = (loc, doClinic, testNames) => {
   if (testNames && testNames.length > 0) {
     testItems = testNames
   } else {
-    testItems = testAbstracts
+    testItems = [ 'localTransfer_tcp_mplex_secio' ]
+    // testItems = testAbstracts // FIXME: temp hack to speed testing
   }
   for (let testAbstract of testItems) {
     if (typeof testAbstract === 'string') {

--- a/runner/lib/schema/add.js
+++ b/runner/lib/schema/add.js
@@ -6,7 +6,12 @@ const addBody = {
   properties: {
     commit: {
       type: 'string',
-      description: 'Commit of the js-IPFS library'
+      description: 'Commit to test against'
+    },
+    project: {
+      type: 'string',
+      description: 'js-ipfs or go-ipfs',
+      enum: ['js-ipfs', 'go-ipfs']
     },
     nightly: {
       type: 'boolean',
@@ -42,7 +47,7 @@ const addBody = {
       }
     }
   },
-  required: ['commit']
+  required: ['commit', 'project']
 }
 
 const addResponse = {

--- a/runner/lib/schema/get.js
+++ b/runner/lib/schema/get.js
@@ -3,7 +3,7 @@
 const getResponse = {
   $id: 'getResponse',
   200: {
-    description: 'Succesful response',
+    description: 'Successful response',
     type: 'array',
     items: {
       type: 'object',

--- a/runner/package-lock.json
+++ b/runner/package-lock.json
@@ -2618,6 +2618,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -3800,7 +3801,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loose-envify": {
           "version": "1.3.1",


### PR DESCRIPTION
Work-in-progress ... do not merge yet

* Separate js-ipfs and go-ipfs Grafana dashboards
* New required param "project" in REST API POST to add a test
  (either 'js-ipfs' or 'go-ipfs')
* Temporary hack to reduce tests to a single test to speed up
  testing (localTransfer_tcp_mplex_secio)

"project" setting is not passed through yet. Will probably need
modifications to ansible scripts and some new code to rebuild
go-ipfs to match requested sha hash. Test may need modifications,
and upload to InfluxDB will need to set the right metadata.