### PR TITLE
Fix connEncryption param in tests

### DIFF
--- a/tests/lib/create-node.js
+++ b/tests/lib/create-node.js
@@ -53,7 +53,7 @@ const parseParams = (options) => {
     options.libp2p.modules.streamMuxer.push(MPLEX)
   }
   if (argv.e === 'secio') {
-    options.libp2p.modules.streamMuxer.push(SECIO)
+    options.libp2p.modules.connEncryption.push(SECIO)
   }
 }
 const CreateNodeJs = async (opt, IPFS, count) => {


### PR DESCRIPTION
I was having trouble getting go-ipfs to connect to js-ipfs in the tests ... the libp2p config wasn't passing in the secio object in the right place.