### PR TITLE
Update Dockerfile gyp permission as root

### DIFF
--- a/Dockerfile-runner
+++ b/Dockerfile-runner
@@ -5,6 +5,7 @@ WORKDIR /opt/app-root/src
 
 COPY runner runner
 USER root
+RUN npm config set user 0
 RUN cd runner && npm install
 USER 1001
 COPY infrastructure/inventory/inventory.yaml infrastructure/inventory/inventory.yaml


### PR DESCRIPTION
To avoid "gyp ERR! stack Error: EACCES: permission denied, mkdir '/opt/app-root/src/runner/node_modules/leveldown/build'" when running gyp as root the suggested line can be added.